### PR TITLE
Add skale-allocator project

### DIFF
--- a/typescript/base/.eslintrc.cjs
+++ b/typescript/base/.eslintrc.cjs
@@ -11,7 +11,7 @@ module.exports = {
     rules: {
         "object-curly-spacing": [ "error", "always" ],
         "padded-blocks": [ "error", "never" ],
-        "one-var": ["error", "consecutive"]
+        "one-var": ["error", "never"]
     },
     ignorePatterns: [
         "lib/**",

--- a/typescript/base/src/instance.ts
+++ b/typescript/base/src/instance.ts
@@ -53,9 +53,12 @@ export abstract class Instance<ContractType> {
         args?: unknown[]
     ): Promise<ContractAddress>;
 
-    async getContract (name: ContractName) {
+    async getContract (name: ContractName, args?: unknown[]) {
         return this.adapter.createContract(
-            await this.getContractAddress(name),
+            await this.getContractAddress(
+                name,
+                args
+            ),
             await this.getContractAbi(name)
         );
     }

--- a/typescript/base/src/instance.ts
+++ b/typescript/base/src/instance.ts
@@ -10,6 +10,23 @@ export type InstanceData = {
     [contractName: string]: MainContractAddress
 }
 
+const defaultVersionAbi = [
+    {
+        "constant": true,
+        "inputs": [],
+        "name": "version",
+        "outputs": [
+            {
+                "name": "",
+                "type": "string"
+            }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+    }
+];
+
 export abstract class Instance<ContractType> {
     protected project: Project<ContractType>;
 
@@ -31,7 +48,10 @@ export abstract class Instance<ContractType> {
         return this.project.network.adapter;
     }
 
-    abstract getContractAddress(name: ContractName): Promise<ContractAddress>;
+    abstract getContractAddress(
+        name: ContractName,
+        args?: unknown[]
+    ): Promise<ContractAddress>;
 
     async getContract (name: ContractName) {
         return this.adapter.createContract(
@@ -42,7 +62,18 @@ export abstract class Instance<ContractType> {
 
     // Protected
 
-    protected abstract queryVersion(): Promise<string>;
+    protected queryVersion () {
+        return this.project.network.adapter.makeCall(
+            {
+                "abi": defaultVersionAbi,
+                "address": this.address
+            },
+            {
+                "args": [],
+                "functionName": "version"
+            }
+        ) as Promise<string>;
+    }
 
     protected async getContractAbi (contractName: string) {
         const abi = await this.getAbi();

--- a/typescript/base/src/projects/factory.ts
+++ b/typescript/base/src/projects/factory.ts
@@ -4,6 +4,7 @@ import { Project } from "../project";
 import {
     ProjectNotFoundError
 } from "../domain/errors/project/projectNotFoundError";
+import { SkaleAllocatorProject } from "./skale-allocator/skaleAllocatorProject";
 import { SkaleManagerProject } from "./skale-manager/skaleManagerProject";
 
 
@@ -11,6 +12,10 @@ export const projects = {
     "mainnetIma": {
         "name": "mainnet-ima",
         "path": "mainnet-ima"
+    },
+    "skaleAllocator": {
+        "name": "skale-allocator",
+        "path": "skale-allocator"
     },
     "skaleManager": {
         "name": "skale-manager",
@@ -32,6 +37,11 @@ export const createProject =
             return new MainnetImaProject<ContractType>(
                 network,
                 projects.mainnetIma
+            );
+        } else if (name === projects.skaleAllocator.name) {
+            return new SkaleAllocatorProject<ContractType>(
+                network,
+                projects.skaleAllocator
             );
         }
         throw new ProjectNotFoundError(`Project with name ${name} is unknown`);

--- a/typescript/base/src/projects/skale-allocator/skaleAllocatorInstance.ts
+++ b/typescript/base/src/projects/skale-allocator/skaleAllocatorInstance.ts
@@ -1,0 +1,45 @@
+import {
+    ContractAddress,
+    ContractName
+} from "../../domain/types";
+import { Instance } from "../../instance";
+
+
+export class SkaleAllocatorInstance<ContractType> extends
+    Instance<ContractType> {
+    getContractAddress (
+        name: ContractName,
+        args?: unknown[]
+    ): Promise<ContractAddress> {
+        if (name === "Allocator") {
+            return Promise.resolve(this.address);
+        }
+        if (name === "Escrow") {
+            const firstArgument = 0;
+            const beneficiary = args?.at(firstArgument) as string;
+            if (!this.project.network.adapter.isAddress(beneficiary)) {
+                throw Error("Beneficiary is not set");
+            }
+            return this.getEscrow(beneficiary);
+        }
+        throw new Error(`Contract ${name} is not found`);
+    }
+
+    // Private
+
+    private async getEscrow (beneficiary: string) {
+        const allocatorAddress = await this.getContractAddress("Allocator");
+        const allocatorAbi = await this.getContractAbi("Allocator");
+
+        return await this.project.network.adapter.makeCall(
+            {
+                "abi": allocatorAbi,
+                "address": allocatorAddress
+            },
+            {
+                "args": [beneficiary],
+                "functionName": "getEscrowAddress"
+            }
+        ) as ContractAddress;
+    }
+}

--- a/typescript/base/src/projects/skale-allocator/skaleAllocatorProject.ts
+++ b/typescript/base/src/projects/skale-allocator/skaleAllocatorProject.ts
@@ -1,0 +1,19 @@
+import { Instance } from "../../instance";
+import { Project } from "../../project";
+import { SkaleAllocatorInstance } from "./skaleAllocatorInstance";
+
+export class SkaleAllocatorProject<ContractType> extends
+    Project<ContractType> {
+    githubRepo = "https://github.com/skalenetwork/skale-manager/";
+
+    createInstance (address: string): Instance<ContractType> {
+        return new SkaleAllocatorInstance(
+            this,
+            address
+        );
+    }
+
+    getAbiFilename (version: string) {
+        return `${this.metadata.name}-${version}-abi.json`;
+    }
+}

--- a/typescript/base/src/projects/skale-allocator/skaleAllocatorProject.ts
+++ b/typescript/base/src/projects/skale-allocator/skaleAllocatorProject.ts
@@ -4,7 +4,7 @@ import { SkaleAllocatorInstance } from "./skaleAllocatorInstance";
 
 export class SkaleAllocatorProject<ContractType> extends
     Project<ContractType> {
-    githubRepo = "https://github.com/skalenetwork/skale-manager/";
+    githubRepo = "https://github.com/skalenetwork/skale-allocator/";
 
     createInstance (address: string): Instance<ContractType> {
         return new SkaleAllocatorInstance(

--- a/typescript/base/src/projects/skale-manager/skaleManagerInstance.ts
+++ b/typescript/base/src/projects/skale-manager/skaleManagerInstance.ts
@@ -57,11 +57,11 @@ export class SkaleManagerInstance<ContractType> extends
 
     async getContractAddress (name: ContractName): Promise<ContractAddress> {
         const contractManagerAbi =
-                await this.getContractAbi("ContractManager"),
-            contractManagerAddress = await this.callSkaleManager(
-                "contractManager",
-                []
-            ) as string;
+                await this.getContractAbi("ContractManager");
+        const contractManagerAddress = await this.callSkaleManager(
+            "contractManager",
+            []
+        ) as string;
 
         return await this.project.network.adapter.makeCall(
             {

--- a/typescript/base/src/retryAdapter.ts
+++ b/typescript/base/src/retryAdapter.ts
@@ -1,12 +1,11 @@
 import { Adapter, ContractData, FunctionCall } from "./adapter";
 import { Abi } from "./domain/types";
 
-const
-    defaultRetryCount = 100,
-    maxDelayMs = 5000,
-    minDelayMs = 10,
-    slowDownCoefficient = 2,
-    speedUpCoefficient = 1.5;
+const defaultRetryCount = 100;
+const maxDelayMs = 5000;
+const minDelayMs = 10;
+const slowDownCoefficient = 2;
+const speedUpCoefficient = 1.5;
 
 
 export class RetryAdapter<ContractType> implements Adapter<ContractType> {
@@ -83,9 +82,8 @@ export class RetryAdapter<ContractType> implements Adapter<ContractType> {
     }
 
     private async waitIfNeeded () {
-        const
-            now = Date.now(),
-            timeFromPreviousCall = now - this.previousCallTimestampMs;
+        const now = Date.now();
+        const timeFromPreviousCall = now - this.previousCallTimestampMs;
         this.previousCallTimestampMs = now;
 
         if (timeFromPreviousCall < this.delayMs) {

--- a/typescript/ethers-v5/src/ethers5Adapter.ts
+++ b/typescript/ethers-v5/src/ethers5Adapter.ts
@@ -27,18 +27,17 @@ export class Ethers5Adapter implements Adapter<BaseContract> {
         contract: ContractData,
         targetFunction: FunctionCall
     ): Promise<unknown> {
-        const
-            contractInterface = new ethers.utils.Interface(contract.abi),
-            [result] = contractInterface.decodeFunctionResult(
-                targetFunction.functionName,
-                await this.provider.call({
-                    "data": contractInterface.encodeFunctionData(
-                        targetFunction.functionName,
-                        targetFunction.args
-                    ),
-                    "to": contract.address
-                })
-            );
+        const contractInterface = new ethers.utils.Interface(contract.abi);
+        const [result] = contractInterface.decodeFunctionResult(
+            targetFunction.functionName,
+            await this.provider.call({
+                "data": contractInterface.encodeFunctionData(
+                    targetFunction.functionName,
+                    targetFunction.args
+                ),
+                "to": contract.address
+            })
+        );
         return result;
     }
 

--- a/typescript/ethers-v6/src/ethers6Adapter.ts
+++ b/typescript/ethers-v6/src/ethers6Adapter.ts
@@ -26,18 +26,17 @@ export class Ethers6Adapter implements Adapter<BaseContract> {
         contract: ContractData,
         targetFunction: FunctionCall
     ): Promise<unknown> {
-        const
-            contractInterface = new ethers.Interface(contract.abi),
-            [result] = contractInterface.decodeFunctionResult(
-                targetFunction.functionName,
-                await this.provider.call({
-                    "data": contractInterface.encodeFunctionData(
-                        targetFunction.functionName,
-                        targetFunction.args
-                    ),
-                    "to": contract.address
-                })
-            );
+        const contractInterface = new ethers.Interface(contract.abi);
+        const [result] = contractInterface.decodeFunctionResult(
+            targetFunction.functionName,
+            await this.provider.call({
+                "data": contractInterface.encodeFunctionData(
+                    targetFunction.functionName,
+                    targetFunction.args
+                ),
+                "to": contract.address
+            })
+        );
         return result;
     }
 


### PR DESCRIPTION
- add `SkaleAllocatorProject` class
- add `SkaleAllocatorInstance` class
- register skale-allocator project
- forbid consecutive vars declarations 
- extend `getContractAddress` and `getContract` methods with optional additional arguments

Resolves #43 