### PR TITLE
Download ABI from release condidate branch if stable is missing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16, 18, 19, 20]
+        node-version: [16, 18, 20, 22]
 
     defaults:
       run:
@@ -55,7 +55,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16, 18, 19, 20]
+        node-version: [16, 18, 20, 22]
 
     defaults:
       run:
@@ -85,7 +85,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16, 18, 19, 20]
+        node-version: [16, 18, 20, 22]
 
     defaults:
       run:
@@ -115,7 +115,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.9, "3.10", 3.11]
+        python-version: [3.9, "3.10", 3.11, 3.12]
 
     defaults:
       run:

--- a/cspell.json
+++ b/cspell.json
@@ -5,7 +5,7 @@
         "yarn-error.log",
         ".gitignore",
         "cspell.json",
-        "**/venv/**",
+        "**/venv*/**",
         "**/node_modules/**",
         "**/__pycache__/**",
         "**/requirements.txt",

--- a/python/src/skale_contracts/project.py
+++ b/python/src/skale_contracts/project.py
@@ -152,10 +152,12 @@ class Project(ABC):
         return abi_file
 
     def _get_github_release_abi_url(self, version: str) -> str:
-        return f'{self.github_repo}releases/download/{version}/{
-            self.get_abi_filename(version)}'
+        return f'{self.github_repo}releases/download/{version}/' + \
+            f'{self.get_abi_filename(version)}'
 
     def _get_github_repository_abi_url(self, version: str) -> str:
-        return f'{self.github_repo.replace(
+        url = self.github_repo.replace(
             'github.com',
-            'raw.githubusercontent.com')}abi/{self.get_abi_filename(version)}'
+            'raw.githubusercontent.com'
+        )
+        return f'{url}abi/{self.get_abi_filename(version)}'

--- a/python/src/skale_contracts/project.py
+++ b/python/src/skale_contracts/project.py
@@ -1,9 +1,15 @@
 """Contains Project class"""
+
+# cspell:words maxsplit
+
 from __future__ import annotations
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from itertools import count
+from typing import TYPE_CHECKING, Generator
+
 from eth_utils.address import to_canonical_address
 import requests
+from semver.version import Version as SemVersion
 
 from .constants import REPOSITORY_URL, NETWORK_TIMEOUT
 from .instance import Instance, InstanceData
@@ -11,6 +17,18 @@ from .instance import Instance, InstanceData
 if TYPE_CHECKING:
     from eth_typing import Address
     from .network import Network
+
+
+def alternative_versions_generator(version: str) -> Generator[str, None, None]:
+    """Provides versions that have compatible ABI"""
+    sem_version = SemVersion.parse(version)
+    if sem_version.prerelease:
+        prerelease_title = sem_version.prerelease.split('.', maxsplit=1)[0]
+        if prerelease_title == 'stable':
+            for prerelease_version in count():
+                yield str(
+                    sem_version.replace(prerelease=f'rc.{prerelease_version}')
+                )
 
 
 class Project(ABC):
@@ -53,11 +71,23 @@ class Project(ABC):
 
     def download_abi_file(self, version: str) -> str:
         """Download file with ABI"""
-        url = self.get_abi_url(version)
-        response = requests.get(url, timeout=NETWORK_TIMEOUT)
-        if response.status_code != 200:
-            raise RuntimeError(f"Can't download abi file from {url}")
-        return response.text
+        exceptions: list[str] = []
+        abi_file = self._download_abi_file_by_version(
+            version,
+            exceptions
+        )
+        if abi_file:
+            return abi_file
+
+        # Stable version can be absent for some time after upgrade.
+        # Try release candidate branch
+        abi_file = self._download_alternative_abi_file(
+            version,
+            exceptions
+        )
+        if abi_file:
+            return abi_file
+        raise RuntimeError('\n'.join(exceptions))
 
     def get_abi_url(self, version: str) -> str:
         """Calculate URL of ABI file"""
@@ -78,3 +108,54 @@ class Project(ABC):
     @abstractmethod
     def create_instance(self, address: Address) -> Instance:
         """Create instance object based on known address"""
+
+    def get_abi_urls(self, version: str) -> list[str]:
+        """Calculate URLs of ABI file"""
+        return [
+            self._get_github_release_abi_url(version),
+            self._get_github_repository_abi_url(version)
+        ]
+
+    # Private
+
+    def _download_abi_file_by_version(
+        self,
+        version: str,
+        exceptions: list[str]
+    ) -> str | None:
+        for abi_url in self.get_abi_urls(version):
+            response = requests.get(abi_url, timeout=NETWORK_TIMEOUT)
+            if response.status_code != 200:
+                exceptions.append(f"Can't download abi file from {abi_url}")
+            else:
+                return response.text
+        return None
+
+    def _download_alternative_abi_file(
+        self,
+        version: str,
+        exceptions: list[str]
+    ) -> str | None:
+        abi_file: str | None = None
+        for alternative_version in alternative_versions_generator(version):
+            alternative_abi_file = self._download_abi_file_by_version(
+                alternative_version,
+                exceptions
+            )
+            if alternative_abi_file:
+                abi_file = alternative_abi_file
+            else:
+                # If abiFile is none
+                # the previous one is the latest
+                break
+
+        return abi_file
+
+    def _get_github_release_abi_url(self, version: str) -> str:
+        return f'{self.github_repo}releases/download/{version}/{
+            self.get_abi_filename(version)}'
+
+    def _get_github_repository_abi_url(self, version: str) -> str:
+        return f'{self.github_repo.replace(
+            'github.com',
+            'raw.githubusercontent.com')}abi/{self.get_abi_filename(version)}'

--- a/typescript/base/src/project.ts
+++ b/typescript/base/src/project.ts
@@ -11,8 +11,8 @@ import {
 import { ProjectMetadata } from "./metadata";
 import { REPOSITORY_URL } from "./domain/constants";
 
-const getAlternativeVersions =
-    function *getAlternativeVersions (version: string) {
+const alternativeVersionsGenerator =
+    function *alternativeVersionsGenerator (version: string) {
         const semVersion = semver.parse(version);
         const wordIndex = 0;
         const nextIndex = 1;
@@ -142,7 +142,8 @@ export abstract class Project<ContractType> {
         exceptions: string[]
     ) {
         let abiFile: SkaleABIFile | null = null;
-        for (const alternativeVersion of getAlternativeVersions(version)) {
+        for (const alternativeVersion
+            of alternativeVersionsGenerator(version)) {
             // Await expression must be executed sequentially
             // eslint-disable-next-line no-await-in-loop
             const alternativeAbiFile = await this.downloadAbiFileByVersion(

--- a/typescript/base/src/project.ts
+++ b/typescript/base/src/project.ts
@@ -1,3 +1,4 @@
+import * as semver from "semver";
 import { Instance, InstanceData } from "./instance";
 import { MainContractAddress, SkaleABIFile } from "./domain/types";
 import axios, { HttpStatusCode } from "axios";
@@ -9,6 +10,22 @@ import {
 } from "./domain/errors/network/networkNotFoundError";
 import { ProjectMetadata } from "./metadata";
 import { REPOSITORY_URL } from "./domain/constants";
+
+const getAlternativeVersions =
+    function *getAlternativeVersions (version: string) {
+        const semVersion = semver.parse(version);
+        const wordIndex = 0;
+        const nextIndex = 1;
+        if (semVersion?.prerelease[wordIndex] === "stable") {
+            for (let prereleaseVersion = 0; ; prereleaseVersion += nextIndex) {
+                semVersion.prerelease = [
+                    "rc",
+                    prereleaseVersion
+                ];
+                yield semVersion.format();
+            }
+        }
+    };
 
 export abstract class Project<ContractType> {
     protected metadata: ProjectMetadata;
@@ -34,28 +51,31 @@ export abstract class Project<ContractType> {
 
     async downloadAbiFile (version: string) {
         const exceptions: string[] = [];
-        for (const abiUrl of this.getAbiUrls(version)) {
-            try {
-                // Await expression should be executed only
-                // when it failed on the previous iteration
-                // eslint-disable-next-line no-await-in-loop
-                const response = await axios.get(abiUrl);
-                return response.data as SkaleABIFile;
-            } catch (exception) {
-                exceptions.push(`\nDownloading from ${abiUrl} - ${exception}`);
-            }
+        let abiFile = await this.downloadAbiFileByVersion(
+            version,
+            exceptions
+        );
+        if (abiFile !== null) {
+            return abiFile;
+        }
+
+        // Stable version can be absent for some time after upgrade.
+        // Try release candidate branch
+        abiFile = await this.downloadAlternativeAbiFile(
+            version,
+            exceptions
+        );
+
+        if (abiFile !== null) {
+            return abiFile;
         }
         throw new Error(exceptions.join(""));
     }
 
     getAbiUrls (version: string) {
         return [
-            `${this.githubRepo}releases/download/` +
-                `${version}/${this.getAbiFilename(version)}`,
-            `${this.githubRepo.replace(
-                "github.com",
-                "raw.githubusercontent.com"
-            )}abi/${this.getAbiFilename(version)}`
+            this.getGithubReleaseAbiUrl(version),
+            this.getGithubRepositoryAbiUrl(version)
         ];
     }
 
@@ -85,5 +105,58 @@ export abstract class Project<ContractType> {
             return this.createInstance(address);
         }
         throw new InstanceNotFound(`Can't download data for instance ${alias}`);
+    }
+
+    private getGithubReleaseAbiUrl (version: string) {
+        return `${this.githubRepo}releases/download/` +
+            `${version}/${this.getAbiFilename(version)}`;
+    }
+
+    private getGithubRepositoryAbiUrl (version: string) {
+        return `${this.githubRepo.replace(
+            "github.com",
+            "raw.githubusercontent.com"
+        )}abi/${this.getAbiFilename(version)}`;
+    }
+
+    private async downloadAbiFileByVersion (
+        version: string,
+        exceptions: string[]
+    ) {
+        for (const abiUrl of this.getAbiUrls(version)) {
+            try {
+                // Await expression should be executed only
+                // when it failed on the previous iteration
+                // eslint-disable-next-line no-await-in-loop
+                const response = await axios.get(abiUrl);
+                return response.data as SkaleABIFile;
+            } catch (exception) {
+                exceptions.push(`\nDownloading from ${abiUrl} - ${exception}`);
+            }
+        }
+        return null;
+    }
+
+    private async downloadAlternativeAbiFile (
+        version: string,
+        exceptions: string[]
+    ) {
+        let abiFile: SkaleABIFile | null = null;
+        for (const alternativeVersion of getAlternativeVersions(version)) {
+            // Await expression must be executed sequentially
+            // eslint-disable-next-line no-await-in-loop
+            const alternativeAbiFile = await this.downloadAbiFileByVersion(
+                alternativeVersion,
+                exceptions
+            );
+            if (alternativeAbiFile === null) {
+                // If abiFile is null
+                // the previous one is the latest
+                break;
+            } else {
+                abiFile = alternativeAbiFile;
+            }
+        }
+        return abiFile;
     }
 }


### PR DESCRIPTION
If the library tries to download ABI from stable release but the ABI is absent
it downloads latest `rc` tag of the same version.