### PR TITLE
changes to deprecate node18 and test newer node versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ on:
       - 'custom-release-*'
 
 env:
-  NODE_VERSION: 20
+  NODE_VERSION: 22
   PYTHON_VERSION: 3.11
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ on:
       - 'custom-release-*'
 
 env:
-  NODE_VERSION: 18
+  NODE_VERSION: 20
   PYTHON_VERSION: 3.11
 
 jobs:
@@ -23,7 +23,7 @@ jobs:
         working-directory: typescript/base
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Node
       uses: actions/setup-node@v4
@@ -76,7 +76,7 @@ jobs:
         working-directory: typescript/ethers-v5
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Node
       uses: actions/setup-node@v4
@@ -133,7 +133,7 @@ jobs:
         working-directory: typescript/ethers-v6
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Node
       uses: actions/setup-node@v4
@@ -190,7 +190,7 @@ jobs:
         working-directory: typescript/viem
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Node
       uses: actions/setup-node@v4
@@ -244,7 +244,7 @@ jobs:
         working-directory: python
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python
       uses: actions/setup-python@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test
 on: [push, pull_request]
 
 env:
-  NODE_VERSION: 20
+  NODE_VERSION: 22
   ENDPOINT: "https://mainnet.infura.io/v3/${{ secrets.INFURA_API_TOKEN }}"
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test
 on: [push, pull_request]
 
 env:
-  NODE_VERSION: 18
+  NODE_VERSION: 20
   ENDPOINT: "https://mainnet.infura.io/v3/${{ secrets.INFURA_API_TOKEN }}"
 
 jobs:
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: "true"
 
@@ -35,14 +35,14 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [20, 22, 24]
 
     defaults:
       run:
         working-directory: typescript/base
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Node
       uses: actions/setup-node@v4
@@ -64,14 +64,14 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [20, 22, 24]
 
     defaults:
       run:
         working-directory: typescript/ethers-v5
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Node
       uses: actions/setup-node@v4
@@ -107,14 +107,14 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [20, 22, 24]
 
     defaults:
       run:
         working-directory: typescript/ethers-v6
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Node
       uses: actions/setup-node@v4
@@ -150,14 +150,14 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [20, 22, 24]
 
     defaults:
       run:
         working-directory: typescript/viem
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Node
       uses: actions/setup-node@v4
@@ -200,7 +200,7 @@ jobs:
         working-directory: python
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python
       uses: actions/setup-python@v4

--- a/typescript/base/package.json
+++ b/typescript/base/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "devDependencies": {
     "@tsconfig/recommended": "^1.0.8",
@@ -26,7 +26,7 @@
   "types": "lib/index.d.ts",
   "version": "1.0.2",
   "dependencies": {
-    "@renovatebot/pep440": "^3.0.20",
+    "@renovatebot/pep440": "^4.1.0",
     "axios": "^1.4.0",
     "dotenv": "^16.5.0",
     "semver": "^7.6.0"

--- a/typescript/base/package.json
+++ b/typescript/base/package.json
@@ -24,7 +24,7 @@
     "eslint": "npx eslint ."
   },
   "types": "lib/index.d.ts",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "dependencies": {
     "@renovatebot/pep440": "^4.1.0",
     "axios": "^1.4.0",

--- a/typescript/base/yarn.lock
+++ b/typescript/base/yarn.lock
@@ -340,10 +340,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@renovatebot/pep440@npm:^3.0.20":
-  version: 3.0.20
-  resolution: "@renovatebot/pep440@npm:3.0.20"
-  checksum: f7014e1774bd7df0db8d08ea9aa8432a668f829f5f6233aee28dc598dc43a4011e5a65962a8d5f295b39b1bb550fd172b85ecb5bb47b8e9cd8ab5db69dabb8e0
+"@renovatebot/pep440@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@renovatebot/pep440@npm:4.1.0"
+  checksum: 70d435f158b2fa2441237ed580e66eb8cf7e4e82c881cdcd998cfb9b3858d9c48e1a944a52c4bf2fa23948d5a1250f1e8cd86a96bca912c798bc930a95a22359
   languageName: node
   linkType: hard
 
@@ -491,7 +491,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@skalenetwork/skale-contracts@workspace:."
   dependencies:
-    "@renovatebot/pep440": ^3.0.20
+    "@renovatebot/pep440": ^4.1.0
     "@tsconfig/recommended": ^1.0.8
     "@types/node": ^22.9.0
     "@typescript-eslint/eslint-plugin": ^6.0.0

--- a/typescript/ethers-v5/package.json
+++ b/typescript/ethers-v5/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "devDependencies": {
     "@skalenetwork/skale-contracts": "portal:../base/",

--- a/typescript/ethers-v5/yarn.lock
+++ b/typescript/ethers-v5/yarn.lock
@@ -829,10 +829,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@renovatebot/pep440@npm:^3.0.20":
-  version: 3.1.0
-  resolution: "@renovatebot/pep440@npm:3.1.0"
-  checksum: 15e81e03269b771892443b526f84fa5b45db7f0b08ee8fec5274cef18f4914398012269ef7d39f11c1a544fdcd67ea15c33e01bfc960a6b6de4fa34aa10dafe3
+"@renovatebot/pep440@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@renovatebot/pep440@npm:4.1.0"
+  checksum: 70d435f158b2fa2441237ed580e66eb8cf7e4e82c881cdcd998cfb9b3858d9c48e1a944a52c4bf2fa23948d5a1250f1e8cd86a96bca912c798bc930a95a22359
   languageName: node
   linkType: hard
 
@@ -996,7 +996,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@skalenetwork/skale-contracts@portal:../base/::locator=%40skalenetwork%2Fskale-contracts-ethers-v5%40workspace%3A."
   dependencies:
-    "@renovatebot/pep440": ^3.0.20
+    "@renovatebot/pep440": ^4.1.0
     axios: ^1.4.0
     dotenv: ^16.5.0
     semver: ^7.6.0

--- a/typescript/ethers-v6/package.json
+++ b/typescript/ethers-v6/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "devDependencies": {
     "@skalenetwork/skale-contracts": "portal:../base/",

--- a/typescript/ethers-v6/yarn.lock
+++ b/typescript/ethers-v6/yarn.lock
@@ -450,10 +450,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@renovatebot/pep440@npm:^3.0.20":
-  version: 3.1.0
-  resolution: "@renovatebot/pep440@npm:3.1.0"
-  checksum: 15e81e03269b771892443b526f84fa5b45db7f0b08ee8fec5274cef18f4914398012269ef7d39f11c1a544fdcd67ea15c33e01bfc960a6b6de4fa34aa10dafe3
+"@renovatebot/pep440@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@renovatebot/pep440@npm:4.1.0"
+  checksum: 70d435f158b2fa2441237ed580e66eb8cf7e4e82c881cdcd998cfb9b3858d9c48e1a944a52c4bf2fa23948d5a1250f1e8cd86a96bca912c798bc930a95a22359
   languageName: node
   linkType: hard
 
@@ -617,7 +617,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@skalenetwork/skale-contracts@portal:../base/::locator=%40skalenetwork%2Fskale-contracts-ethers-v6%40workspace%3A."
   dependencies:
-    "@renovatebot/pep440": ^3.0.20
+    "@renovatebot/pep440": ^4.1.0
     axios: ^1.4.0
     dotenv: ^16.5.0
     semver: ^7.6.0

--- a/typescript/viem/yarn.lock
+++ b/typescript/viem/yarn.lock
@@ -457,10 +457,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@renovatebot/pep440@npm:^3.0.20":
-  version: 3.1.0
-  resolution: "@renovatebot/pep440@npm:3.1.0"
-  checksum: 15e81e03269b771892443b526f84fa5b45db7f0b08ee8fec5274cef18f4914398012269ef7d39f11c1a544fdcd67ea15c33e01bfc960a6b6de4fa34aa10dafe3
+"@renovatebot/pep440@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@renovatebot/pep440@npm:4.1.0"
+  checksum: 70d435f158b2fa2441237ed580e66eb8cf7e4e82c881cdcd998cfb9b3858d9c48e1a944a52c4bf2fa23948d5a1250f1e8cd86a96bca912c798bc930a95a22359
   languageName: node
   linkType: hard
 
@@ -652,7 +652,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@skalenetwork/skale-contracts@portal:../base/::locator=%40skalenetwork%2Fskale-contracts-viem%40workspace%3A."
   dependencies:
-    "@renovatebot/pep440": ^3.0.20
+    "@renovatebot/pep440": ^4.1.0
     axios: ^1.4.0
     dotenv: ^16.5.0
     semver: ^7.6.0


### PR DESCRIPTION
Fixes #478

Bumps skale-contracts typescript libraries from 1.X to 2.X