### PR TITLE
Allow to extend Instances with contract Types

### DIFF
--- a/typescript/base/package.json
+++ b/typescript/base/package.json
@@ -24,7 +24,7 @@
     "eslint": "npx eslint ."
   },
   "types": "lib/index.d.ts",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "dependencies": {
     "@renovatebot/pep440": "^4.1.0",
     "axios": "^1.4.0",

--- a/typescript/base/src/instance.ts
+++ b/typescript/base/src/instance.ts
@@ -61,7 +61,14 @@ const processPep440 = (pyVersion: Pep440Version) => {
     return stringify(pyVersion)!;
 };
 
-export abstract class Instance<ContractType, ContractName extends string> {
+export abstract class Instance<
+    ContractType,
+    ContractName extends string,
+    TypesMap extends Record<ContractName, ContractType> = Record<
+        ContractName,
+        ContractType
+    >
+> {
     protected project: Project<ContractType, ContractName>;
 
     addressContainer: ContractAddressMap;
@@ -95,14 +102,17 @@ export abstract class Instance<ContractType, ContractName extends string> {
         args?: unknown[]
     ): Promise<ContractAddress>;
 
-    async getContract (name: ContractName, args?: unknown[]) {
+    async getContract<Name extends ContractName> (
+        name: Name,
+        args?: unknown[]
+    ): Promise<TypesMap[Name]> {
         return this.adapter.createContract(
             await this.getContractAddress(
                 name,
                 args
             ),
             await this.getContractAbi(name)
-        );
+        ) as TypesMap[Name];
     }
 
     // Protected

--- a/typescript/base/src/project.ts
+++ b/typescript/base/src/project.ts
@@ -49,14 +49,19 @@ export abstract class Project<ContractType, ContractName extends string> {
         this.metadata = metadata;
     }
 
-    getInstance (target: string | MainContractAddress | ContractAddressMap) {
+    getInstance <
+        TypesMap extends Record<ContractName, ContractType> = Record<
+            ContractName,
+            ContractType
+        >
+    > (target: string | MainContractAddress | ContractAddressMap) {
         if (
             this.network.adapter.isAddress(target) ||
             this.isContractAddressMap(target)
         ) {
-            return this.getInstanceByAddress(target);
+            return this.getInstanceByAddress<TypesMap>(target);
         }
-        return this.getInstanceByAlias(target);
+        return this.getInstanceByAlias<TypesMap>(target);
     }
 
     async downloadAbiFile (version: string) {
@@ -99,8 +104,13 @@ export abstract class Project<ContractType, ContractName extends string> {
         throw new NetworkNotFoundError("Network is unknown");
     }
 
-    abstract createInstance(address: MainContractAddress | ContractAddressMap):
-        Instance<ContractType, ContractName>;
+    abstract createInstance<
+        TypesMap extends Record<ContractName, ContractType> = Record<
+            ContractName,
+            ContractType
+        >
+    >(address: MainContractAddress | ContractAddressMap):
+        Instance<ContractType, ContractName, TypesMap>;
 
     public isContractAddressMap = (
         obj: unknown
@@ -122,17 +132,27 @@ export abstract class Project<ContractType, ContractName extends string> {
 
     // Private
 
-    private getInstanceByAddress (
+    private getInstanceByAddress <
+        TypesMap extends Record<ContractName, ContractType> = Record<
+            ContractName,
+            ContractType
+        >
+    > (
         address: MainContractAddress | ContractAddressMap
     ) {
-        return this.createInstance(address);
+        return this.createInstance<TypesMap>(address);
     }
 
-    private async getInstanceByAlias (alias: string) {
+    private async getInstanceByAlias <
+        TypesMap extends Record<ContractName, ContractType> = Record<
+            ContractName,
+            ContractType
+        >
+    > (alias: string) {
         const response = await axios.get(this.getInstanceDataUrl(alias));
         if (response.status === HttpStatusCode.Ok) {
             const [address] = Object.values(response.data as InstanceData);
-            return this.createInstance(address);
+            return this.createInstance<TypesMap>(address);
         }
         throw new InstanceNotFound(`Can't download data for instance ${alias}`);
     }

--- a/typescript/base/src/projects/credit-station/CreditStationInstance.ts
+++ b/typescript/base/src/projects/credit-station/CreditStationInstance.ts
@@ -20,8 +20,12 @@ const GET_AUTHORITY_ABI = [
 ];
 export abstract class CreditStationInstance<
     ContractType,
-    ContractName extends string
-> extends Instance<ContractType, ContractName> {
+    ContractName extends string,
+    TypesMap extends Record<ContractName, ContractType> = Record<
+        ContractName,
+        ContractType
+    >
+> extends Instance<ContractType, ContractName, TypesMap> {
     getContractAddress (
         name: ContractName
     ): Promise<ContractAddress> {

--- a/typescript/base/src/projects/credit-station/mainnet/MainnetCreditStationInstance.ts
+++ b/typescript/base/src/projects/credit-station/mainnet/MainnetCreditStationInstance.ts
@@ -14,8 +14,20 @@ export type MainnetCreditStationContractName =
     `${MainnetCreditStationContract}`;
 
 
-export class MainnetCreditStationInstance<ContractType> extends
-    CreditStationInstance<ContractType, MainnetCreditStationContractName> {
+export interface MainnetCreditStationDefaultTypesMap<ContractType>
+    extends Record<MainnetCreditStationContractName, ContractType> {}
+
+export class MainnetCreditStationInstance<
+    ContractType,
+    TypesMap extends Record<
+        MainnetCreditStationContractName,
+        ContractType
+    > = MainnetCreditStationDefaultTypesMap<ContractType>
+> extends CreditStationInstance<
+    ContractType,
+    MainnetCreditStationContractName,
+    TypesMap
+> {
     contractNames = Object.values(
         MainnetCreditStationContract
     ) as MainnetCreditStationContractName[];

--- a/typescript/base/src/projects/credit-station/mainnet/MainnetCreditStationProject.ts
+++ b/typescript/base/src/projects/credit-station/mainnet/MainnetCreditStationProject.ts
@@ -3,9 +3,9 @@
 import { ContractAddressMap, MainContractAddress } from "../../../domain/types";
 import {
     MainnetCreditStationContractName,
+    MainnetCreditStationDefaultTypesMap,
     MainnetCreditStationInstance
 } from "./MainnetCreditStationInstance";
-import { CreditStationInstance } from "../CreditStationInstance";
 import { CreditStationProject } from "../CreditStationProject";
 
 
@@ -13,12 +13,26 @@ export class MainnetCreditStationProject<ContractType> extends
     CreditStationProject<ContractType, MainnetCreditStationContractName> {
     mainContractName = "Ledger";
 
-    createInstance (
+    createInstance<
+        TypesMap extends Record<MainnetCreditStationContractName, ContractType>=
+            MainnetCreditStationDefaultTypesMap<ContractType>
+    > (
         address: MainContractAddress | ContractAddressMap
-    ): CreditStationInstance<ContractType, MainnetCreditStationContractName> {
-        return new MainnetCreditStationInstance<ContractType>(
+    ): MainnetCreditStationInstance<ContractType, TypesMap> {
+        return new MainnetCreditStationInstance<ContractType, TypesMap>(
             this,
             address
         );
+    }
+
+    getInstance<
+        TypesMap extends Record<MainnetCreditStationContractName, ContractType>=
+            MainnetCreditStationDefaultTypesMap<ContractType>
+    > (
+        target: string | MainContractAddress | ContractAddressMap
+    ): MainnetCreditStationInstance<ContractType, TypesMap> {
+        return super.getInstance<TypesMap>(
+            target
+        ) as MainnetCreditStationInstance<ContractType, TypesMap>;
     }
 }

--- a/typescript/base/src/projects/credit-station/schain/SchainCreditStationInstance.ts
+++ b/typescript/base/src/projects/credit-station/schain/SchainCreditStationInstance.ts
@@ -13,8 +13,20 @@ export enum SchainCreditStationContract {
 
 export type SchainCreditStationContractName = `${SchainCreditStationContract}`;
 
-export class SchainCreditStationInstance<ContractType> extends
-    CreditStationInstance<ContractType, SchainCreditStationContractName> {
+
+export interface SchainCreditStationDefaultTypesMap<ContractType>
+    extends Record<SchainCreditStationContractName, ContractType> {}
+export class SchainCreditStationInstance<
+    ContractType,
+    TypesMap extends Record<
+        SchainCreditStationContractName,
+        ContractType
+    > = SchainCreditStationDefaultTypesMap<ContractType>
+> extends CreditStationInstance<
+    ContractType,
+    SchainCreditStationContractName,
+    TypesMap
+> {
     contractNames = Object.values(
         SchainCreditStationContract
     ) as SchainCreditStationContractName[];

--- a/typescript/base/src/projects/credit-station/schain/SchainCreditStationProject.ts
+++ b/typescript/base/src/projects/credit-station/schain/SchainCreditStationProject.ts
@@ -1,9 +1,9 @@
 import { ContractAddressMap, MainContractAddress } from "../../../domain/types";
 import {
     SchainCreditStationContractName,
+    SchainCreditStationDefaultTypesMap,
     SchainCreditStationInstance
 } from "./SchainCreditStationInstance";
-import { CreditStationInstance } from "../CreditStationInstance";
 import { CreditStationProject } from "../CreditStationProject";
 
 
@@ -11,12 +11,25 @@ export class SchainCreditStationProject<ContractType> extends
     CreditStationProject<ContractType, SchainCreditStationContractName> {
     mainContractName = "Ledger";
 
-    createInstance (
+    createInstance<
+        TypesMap extends Record<SchainCreditStationContractName, ContractType>
+    > (
         address: MainContractAddress | ContractAddressMap
-    ): CreditStationInstance<ContractType, SchainCreditStationContractName> {
-        return new SchainCreditStationInstance<ContractType>(
+    ): SchainCreditStationInstance<ContractType, TypesMap> {
+        return new SchainCreditStationInstance<ContractType, TypesMap>(
             this,
             address
         );
+    }
+
+    getInstance<
+        TypesMap extends Record<SchainCreditStationContractName, ContractType>=
+            SchainCreditStationDefaultTypesMap<ContractType>
+    > (
+        target: string | MainContractAddress | ContractAddressMap
+    ): SchainCreditStationInstance<ContractType, TypesMap> {
+        return super.getInstance<TypesMap>(
+            target
+        ) as SchainCreditStationInstance<ContractType, TypesMap>;
     }
 }

--- a/typescript/base/src/projects/factory.ts
+++ b/typescript/base/src/projects/factory.ts
@@ -58,12 +58,40 @@ export type SkaleContractNames =
     SchainCreditStationContractName |
     MainnetCreditStationContractName;
 
-type ProjectConstructor<ContractType> = new (
+// Map each project name to its specific contract name type
+type ProjectContractNameMap = {
+    [SkaleProject.MAINNET_IMA]: MainnetImaContractName;
+    [SkaleProject.PAYMASTER]: PaymasterContractName;
+    [SkaleProject.SCHAIN_IMA]: SchainImaContractName;
+    [SkaleProject.SKALE_ALLOCATOR]: SkaleAllocatorContractName;
+    [SkaleProject.SKALE_MANAGER]: SkaleManagerContractName;
+    [SkaleProject.FAIR_MANAGER]: FairManagerContractName;
+    [SkaleProject.MAINNET_CREDIT_STATION]: MainnetCreditStationContractName;
+    [SkaleProject.SCHAIN_CREDIT_STATION]: SchainCreditStationContractName;
+};
+
+// Map each project name to its specific project class type
+type ProjectClassMap<ContractType> = {
+    [SkaleProject.MAINNET_IMA]: MainnetImaProject<ContractType>;
+    [SkaleProject.PAYMASTER]: PaymasterProject<ContractType>;
+    [SkaleProject.SCHAIN_IMA]: SchainImaProject<ContractType>;
+    [SkaleProject.SKALE_ALLOCATOR]: SkaleAllocatorProject<ContractType>;
+    [SkaleProject.SKALE_MANAGER]: SkaleManagerProject<ContractType>;
+    [SkaleProject.FAIR_MANAGER]: FairManagerProject<ContractType>;
+    [SkaleProject.MAINNET_CREDIT_STATION]:
+        MainnetCreditStationProject<ContractType>;
+    [SkaleProject.SCHAIN_CREDIT_STATION]:
+        SchainCreditStationProject<ContractType>;
+};
+
+type ProjectConstructor<ContractType, ContractName extends string> = new (
     network: Network<ContractType>,
     metadata: { name: SkaleProjectName; path: SkaleProjectName }
-) => Project<ContractType, SkaleContractNames>;
+) => Project<ContractType, ContractName>;
 
-const projectMap: Record<SkaleProject, ProjectConstructor<unknown>> = {
+const projectMap: {
+    [K in SkaleProject]: ProjectConstructor<unknown, ProjectContractNameMap[K]>
+} = {
     [SkaleProject.MAINNET_IMA]: MainnetImaProject,
     [SkaleProject.PAYMASTER]: PaymasterProject,
     [SkaleProject.SCHAIN_IMA]: SchainImaProject,
@@ -74,10 +102,23 @@ const projectMap: Record<SkaleProject, ProjectConstructor<unknown>> = {
     [SkaleProject.SCHAIN_CREDIT_STATION]: SchainCreditStationProject
 };
 
-export const createProject = function createProject<ContractType> (
+// Type helper to infer the correct return type based on project name
+// This returns the specific project class type (e.g., PaymasterProject)
+// rather than the general Project type
+type InferProjectType<
+    ContractType,
+    Name extends SkaleProjectName
+> = Name extends SkaleProject
+    ? ProjectClassMap<ContractType>[Name]
+    : Project<ContractType, SkaleContractNames>;
+
+export const createProject = function createProject<
+    ContractType,
+    Name extends SkaleProjectName = SkaleProjectName
+> (
     network: Network<ContractType>,
-    name: SkaleProjectName
-): Project<ContractType, SkaleContractNames> {
+    name: Name
+): InferProjectType<ContractType, Name> {
     const metadata = {
         name,
         "path": name
@@ -91,5 +132,5 @@ export const createProject = function createProject<ContractType> (
     return new ProjectClass(
         network,
         metadata
-    ) as Project<ContractType, SkaleContractNames>;
+    ) as InferProjectType<ContractType, Name>;
 };

--- a/typescript/base/src/projects/fair-manager/fairManagerInstance.ts
+++ b/typescript/base/src/projects/fair-manager/fairManagerInstance.ts
@@ -16,8 +16,16 @@ export enum FairManagerContract {
 const ZERO_ID = 0n;
 export type FairManagerContractName = `${FairManagerContract}`;
 
-export class FairManagerInstance<ContractType> extends
-    Instance<ContractType, FairManagerContractName> {
+export interface FairManagerDefaultTypesMap<ContractType>
+    extends Record<FairManagerContractName, ContractType> {}
+
+export class FairManagerInstance<
+    ContractType,
+    TypesMap extends Record<
+        FairManagerContractName,
+        ContractType
+    > = FairManagerDefaultTypesMap<ContractType>
+> extends Instance<ContractType, FairManagerContractName, TypesMap> {
     contractNames =
         Object.values(FairManagerContract) as FairManagerContractName[];
 

--- a/typescript/base/src/projects/fair-manager/fairManagerProject.ts
+++ b/typescript/base/src/projects/fair-manager/fairManagerProject.ts
@@ -1,23 +1,38 @@
 import { ContractAddressMap, MainContractAddress } from "../../domain/types";
 import {
     FairManagerContractName,
+    FairManagerDefaultTypesMap,
     FairManagerInstance
 } from "./fairManagerInstance";
-import { Instance } from "../../instance";
 import { Project } from "../../project";
 
-export class FairManagerProject<ContractType> extends
-    Project<ContractType, FairManagerContractName> {
+export class FairManagerProject<
+    ContractType
+> extends Project<ContractType, FairManagerContractName> {
     githubRepo = "https://github.com/skalenetwork/fair-manager/";
 
     mainContractName = "Committee";
 
-    createInstance (address: MainContractAddress | ContractAddressMap)
-        : Instance<ContractType, FairManagerContractName> {
-        return new FairManagerInstance(
+    createInstance<
+        TypesMap extends Record<FairManagerContractName, ContractType> =
+            FairManagerDefaultTypesMap<ContractType>
+    > (address: MainContractAddress | ContractAddressMap)
+        : FairManagerInstance<ContractType, TypesMap> {
+        return new FairManagerInstance<ContractType, TypesMap>(
             this,
             address
         );
+    }
+
+    getInstance<
+        TypesMap extends Record<FairManagerContractName, ContractType> =
+            FairManagerDefaultTypesMap<ContractType>
+    > (
+        target: string | MainContractAddress | ContractAddressMap
+    ): FairManagerInstance<ContractType, TypesMap> {
+        return super.getInstance<TypesMap>(
+            target
+        ) as FairManagerInstance<ContractType, TypesMap>;
     }
 
     getAbiFilename (version: string) {

--- a/typescript/base/src/projects/ima/ImaInstance.ts
+++ b/typescript/base/src/projects/ima/ImaInstance.ts
@@ -18,8 +18,14 @@ const messageProxyAbi = [
     }
 ];
 
-export abstract class ImaInstance<ContractType, ContractName extends string>
-    extends Instance<ContractType, ContractName> {
+export abstract class ImaInstance<
+    ContractType,
+    ContractName extends string,
+    TypesMap extends Record<ContractName, ContractType> = Record<
+        ContractName,
+        ContractType
+    >
+> extends Instance<ContractType, ContractName, TypesMap> {
     async queryVersion () {
         return await this.callMessageProxy(
             "version",

--- a/typescript/base/src/projects/ima/mainnet/MainnetImaInstance.ts
+++ b/typescript/base/src/projects/ima/mainnet/MainnetImaInstance.ts
@@ -14,7 +14,8 @@ export enum MainnetImaContract {
 }
 export type MainnetImaContractName = `${MainnetImaContract}`;
 
-
+export interface MainnetImaDefaultTypesMap<ContractType>
+    extends Record<MainnetImaContractName, ContractType> {}
 const contractManagerAbi = [
     {
         "constant": true,
@@ -37,8 +38,13 @@ const contractManagerAbi = [
     }
 ];
 
-export class MainnetImaInstance<ContractType> extends
-    ImaInstance<ContractType, MainnetImaContractName> {
+export class MainnetImaInstance<
+    ContractType,
+    TypesMap extends Record<
+        MainnetImaContractName,
+        ContractType
+    > = MainnetImaDefaultTypesMap<ContractType>
+> extends ImaInstance<ContractType, MainnetImaContractName, TypesMap> {
     private contractManager: ContractData | undefined;
 
     contractNames =

--- a/typescript/base/src/projects/ima/mainnet/MainnetImaProject.ts
+++ b/typescript/base/src/projects/ima/mainnet/MainnetImaProject.ts
@@ -2,24 +2,39 @@ import { ContractAddressMap, MainContractAddress } from "../../../domain/types";
 import {
     MainnetImaContract,
     MainnetImaContractName,
+    MainnetImaDefaultTypesMap,
     MainnetImaInstance
 } from "./MainnetImaInstance";
 import { ImaProject } from "../ImaProject";
-import { Instance } from "../../../instance";
 
-export class MainnetImaProject<ContractType> extends
-    ImaProject<ContractType, MainnetImaContractName> {
+export class MainnetImaProject<
+    ContractType
+> extends ImaProject<ContractType, MainnetImaContractName> {
     mainContractName = MainnetImaContract.MESSAGE_PROXY_FOR_MAINNET;
 
     getAbiFilename (version: string) {
         return `${this.metadata.name}-${version}-abi.json`;
     }
 
-    createInstance (address: MainContractAddress | ContractAddressMap)
-        : Instance<ContractType, MainnetImaContractName> {
-        return new MainnetImaInstance(
+    createInstance<
+        TypesMap extends Record<MainnetImaContractName, ContractType> =
+            MainnetImaDefaultTypesMap<ContractType>
+    > (address: MainContractAddress | ContractAddressMap)
+        : MainnetImaInstance<ContractType, TypesMap> {
+        return new MainnetImaInstance<ContractType, TypesMap>(
             this,
             address
         );
+    }
+
+    getInstance<
+        TypesMap extends Record<MainnetImaContractName, ContractType>=
+            MainnetImaDefaultTypesMap<ContractType>
+    > (
+        target: string | MainContractAddress | ContractAddressMap
+    ): MainnetImaInstance<ContractType, TypesMap> {
+        return super.getInstance<TypesMap>(
+            target
+        ) as MainnetImaInstance<ContractType, TypesMap>;
     }
 }

--- a/typescript/base/src/projects/ima/schain/SchainImaInstance.ts
+++ b/typescript/base/src/projects/ima/schain/SchainImaInstance.ts
@@ -15,8 +15,16 @@ export enum SchainImaContract {
 }
 export type SchainImaContractName = `${SchainImaContract}`;
 
-export class SchainImaInstance<ContractType> extends
-    ImaInstance<ContractType, SchainImaContractName> {
+export interface SchainImaDefaultTypesMap<ContractType>
+    extends Record<SchainImaContractName, ContractType> {}
+
+export class SchainImaInstance<
+    ContractType,
+    TypesMap extends Record<
+        SchainImaContractName,
+        ContractType
+    > = SchainImaDefaultTypesMap<ContractType>
+> extends ImaInstance<ContractType, SchainImaContractName, TypesMap> {
     contractNames = Object.values(SchainImaContract) as SchainImaContractName[];
 
     static PREDEPLOYED = new Map<string, string>([

--- a/typescript/base/src/projects/ima/schain/SchainImaProject.ts
+++ b/typescript/base/src/projects/ima/schain/SchainImaProject.ts
@@ -6,11 +6,11 @@ import {
 import {
     SchainImaContract,
     SchainImaContractName,
+    SchainImaDefaultTypesMap,
     SchainImaInstance
 } from "./SchainImaInstance";
 
 import { ImaProject } from "../ImaProject";
-import { Instance } from "../../../instance";
 import {
     PREDEPLOYED_ALIAS
 } from "../../../domain/constants";
@@ -23,7 +23,10 @@ export class SchainImaProject<ContractType> extends
         return `${this.metadata.name}-${version}-abi.json`;
     }
 
-    getInstance (
+    getInstance <
+        TypesMap extends Record<SchainImaContractName, ContractType>=
+            SchainImaDefaultTypesMap<ContractType>
+    > (
         aliasOrAddress:
             | SchainImaContractName
             | MainContractAddress
@@ -31,17 +34,25 @@ export class SchainImaProject<ContractType> extends
             | typeof PREDEPLOYED_ALIAS
     ) {
         if (aliasOrAddress === PREDEPLOYED_ALIAS) {
-            return this.createInstance(SchainImaInstance.PREDEPLOYED.
+            return this.createInstance<TypesMap>(SchainImaInstance.PREDEPLOYED.
                 get(this.mainContractName)! as ContractAddress);
         }
         return (
-            super.getInstance(aliasOrAddress) as SchainImaInstance<ContractType>
+            super.getInstance(aliasOrAddress) as SchainImaInstance<
+                ContractType,
+                TypesMap
+            >
         );
     }
 
-    createInstance (address: MainContractAddress | ContractAddressMap)
-        : Instance<ContractType, SchainImaContractName> {
-        return new SchainImaInstance(
+    createInstance <
+        TypesMap extends Record<
+            SchainImaContractName,
+            ContractType
+        > = SchainImaDefaultTypesMap<ContractType>
+    > (address: MainContractAddress | ContractAddressMap)
+        : SchainImaInstance<ContractType, TypesMap> {
+        return new SchainImaInstance<ContractType, TypesMap>(
             this,
             address
         );

--- a/typescript/base/src/projects/paymaster/paymasterInstance.ts
+++ b/typescript/base/src/projects/paymaster/paymasterInstance.ts
@@ -9,8 +9,18 @@ export enum PaymasterContract {
     FAST_FORWARD_PAYMASTER = "FastForwardPaymaster"
 }
 export type PaymasterContractName = `${PaymasterContract}`;
-export class PaymasterInstance<ContractType> extends
-    Instance<ContractType, PaymasterContractName> {
+
+
+export interface PaymasterDefaultTypesMap<ContractType>
+    extends Record<PaymasterContractName, ContractType> {}
+
+export class PaymasterInstance<
+    ContractType,
+    TypesMap extends Record<
+        PaymasterContractName,
+        ContractType
+    > = PaymasterDefaultTypesMap<ContractType>
+> extends Instance<ContractType, PaymasterContractName, TypesMap> {
     contractNames = Object.values(PaymasterContract);
 
     async getContractAddress (

--- a/typescript/base/src/projects/paymaster/paymasterProject.ts
+++ b/typescript/base/src/projects/paymaster/paymasterProject.ts
@@ -2,23 +2,38 @@ import { ContractAddressMap, MainContractAddress } from "../../domain/types";
 import {
     PaymasterContract,
     PaymasterContractName,
+    PaymasterDefaultTypesMap,
     PaymasterInstance
 } from "./paymasterInstance";
-import { Instance } from "../../instance";
 import { Project } from "../../project";
 
-export class PaymasterProject<ContractType> extends
-    Project<ContractType, PaymasterContractName> {
+export class PaymasterProject<
+    ContractType,
+> extends Project<ContractType, PaymasterContractName> {
     githubRepo = "https://github.com/skalenetwork/paymaster/";
 
     mainContractName = PaymasterContract.PAYMASTER;
 
-    createInstance (address: MainContractAddress | ContractAddressMap)
-        : Instance<ContractType, PaymasterContractName> {
-        return new PaymasterInstance(
+    createInstance<
+        TypesMap extends Record<PaymasterContractName, ContractType>=
+            PaymasterDefaultTypesMap<ContractType>
+    > (address: MainContractAddress | ContractAddressMap)
+        : PaymasterInstance<ContractType, TypesMap> {
+        return new PaymasterInstance<ContractType, TypesMap>(
             this,
             address
         );
+    }
+
+    getInstance<
+        TypesMap extends Record<PaymasterContractName, ContractType>=
+            PaymasterDefaultTypesMap<ContractType>
+    > (
+        target: string | MainContractAddress | ContractAddressMap
+    ): PaymasterInstance<ContractType, TypesMap> {
+        return super.getInstance<TypesMap>(
+            target
+        ) as PaymasterInstance<ContractType, TypesMap>;
     }
 
     getAbiFilename (version: string) {

--- a/typescript/base/src/projects/skale-allocator/skaleAllocatorInstance.ts
+++ b/typescript/base/src/projects/skale-allocator/skaleAllocatorInstance.ts
@@ -8,8 +8,17 @@ export enum SkaleAllocatorContract {
     ESCROW = "Escrow",
 }
 export type SkaleAllocatorContractName = `${SkaleAllocatorContract}`;
-export class SkaleAllocatorInstance<ContractType> extends
-    Instance<ContractType, SkaleAllocatorContractName> {
+
+export interface SkaleAllocatorDefaultTypesMap<ContractType>
+    extends Record<SkaleAllocatorContractName, ContractType> {}
+
+export class SkaleAllocatorInstance<
+    ContractType,
+    TypesMap extends Record<
+        SkaleAllocatorContractName,
+        ContractType
+    > = SkaleAllocatorDefaultTypesMap<ContractType>
+> extends Instance<ContractType, SkaleAllocatorContractName, TypesMap> {
     contractNames =
         Object.values(SkaleAllocatorContract);
 

--- a/typescript/base/src/projects/skale-allocator/skaleAllocatorProject.ts
+++ b/typescript/base/src/projects/skale-allocator/skaleAllocatorProject.ts
@@ -1,9 +1,9 @@
 import { ContractAddressMap, MainContractAddress } from "../../domain/types";
 import {
     SkaleAllocatorContractName,
+    SkaleAllocatorDefaultTypesMap,
     SkaleAllocatorInstance
 } from "./skaleAllocatorInstance";
-import { Instance } from "../../instance";
 import { Project } from "../../project";
 
 
@@ -13,12 +13,26 @@ export class SkaleAllocatorProject<ContractType> extends
 
     mainContractName = "SkaleAllocator";
 
-    createInstance (address: MainContractAddress | ContractAddressMap)
-        : Instance<ContractType, SkaleAllocatorContractName> {
-        return new SkaleAllocatorInstance(
+    createInstance<
+        TypesMap extends Record<SkaleAllocatorContractName, ContractType>=
+            SkaleAllocatorDefaultTypesMap<ContractType>
+    > (address: MainContractAddress | ContractAddressMap)
+        : SkaleAllocatorInstance<ContractType, TypesMap> {
+        return new SkaleAllocatorInstance<ContractType, TypesMap>(
             this,
             address
         );
+    }
+
+    getInstance<
+        TypesMap extends Record<SkaleAllocatorContractName, ContractType>=
+            SkaleAllocatorDefaultTypesMap<ContractType>
+        > (
+        target: string | MainContractAddress | ContractAddressMap
+    ): SkaleAllocatorInstance<ContractType, TypesMap> {
+        return super.getInstance<TypesMap>(
+            target
+        ) as SkaleAllocatorInstance<ContractType, TypesMap>;
     }
 
     getAbiFilename (version: string) {

--- a/typescript/base/src/projects/skale-manager/skaleManagerInstance.ts
+++ b/typescript/base/src/projects/skale-manager/skaleManagerInstance.ts
@@ -38,6 +38,10 @@ export enum SkaleManagerContract {
 }
 export type SkaleManagerContractName = `${SkaleManagerContract}`;
 
+export interface SkaleManagerDefaultTypesMap<ContractType>
+    extends Record<SkaleManagerContractName, ContractType> {}
+
+
 const skaleManagerAbi = [
     {
         "inputs": [],
@@ -68,8 +72,11 @@ const skaleManagerAbi = [
     }
 ];
 
-export class SkaleManagerInstance<ContractType> extends
-    Instance<ContractType, SkaleManagerContractName> {
+export class SkaleManagerInstance<
+    ContractType,
+    TypesMap extends Record<SkaleManagerContractName, ContractType> =
+        SkaleManagerDefaultTypesMap<ContractType>
+> extends Instance<ContractType, SkaleManagerContractName, TypesMap> {
     contractNames =
         Object.values(SkaleManagerContract) as SkaleManagerContractName[];
 

--- a/typescript/base/src/projects/skale-manager/skaleManagerProject.ts
+++ b/typescript/base/src/projects/skale-manager/skaleManagerProject.ts
@@ -2,9 +2,9 @@ import { ContractAddressMap, MainContractAddress } from "../../domain/types";
 import {
     SkaleManagerContract,
     SkaleManagerContractName,
+    SkaleManagerDefaultTypesMap,
     SkaleManagerInstance
 } from "./skaleManagerInstance";
-import { Instance } from "../../instance";
 import { Project } from "../../project";
 
 export class SkaleManagerProject<ContractType> extends
@@ -13,12 +13,26 @@ export class SkaleManagerProject<ContractType> extends
 
     mainContractName = SkaleManagerContract.SKALE_MANAGER;
 
-    createInstance (address: MainContractAddress | ContractAddressMap)
-        : Instance<ContractType, SkaleManagerContractName> {
-        return new SkaleManagerInstance(
+    createInstance<
+        TypesMap extends Record<SkaleManagerContractName, ContractType>=
+            SkaleManagerDefaultTypesMap<ContractType>
+    > (address: MainContractAddress | ContractAddressMap)
+        : SkaleManagerInstance<ContractType, TypesMap> {
+        return new SkaleManagerInstance<ContractType, TypesMap>(
             this,
             address
         );
+    }
+
+    getInstance<
+        TypesMap extends Record<SkaleManagerContractName, ContractType>=
+            SkaleManagerDefaultTypesMap<ContractType>
+    > (
+        target: string | MainContractAddress | ContractAddressMap
+    ): SkaleManagerInstance<ContractType, TypesMap> {
+        return super.getInstance<TypesMap>(
+            target
+        ) as SkaleManagerInstance<ContractType, TypesMap>;
     }
 
     getAbiFilename (version: string) {


### PR DESCRIPTION
Fixes #410 (Proposal)

**Description:** Fully backward compatible enhancement of previous typescript version of skale-contracts. Allows to inject a Record collection of types for an instance's contracts.
Use of the new feature is completely optional.

## Improvements

### **1.  `createProject` accurately infers type of project from the name it receives as input**

```typescript
const project = createProject(network, "fair-manager");
// Old: type of project is Project<SkaleContractNames, ContractType>
// New: type of project is FairManagerProject<FairManagerContractNames, ContractType>
// Consequentially, instances created will be of Type FairManagerInstance.
``` 

### **2. Allows to create custom TypeMaps so that Instance.getContract() returns the right type**
```typescript
import {Committee, Status /*, ...*/} from "@skalenetwork/fair-manager-types/**"

type FairManagerTypeMap = {
   'Committee': Committee;
   'Status': Status;
   // ... Requires ALL names from FairManagerContractNames
}

const project = createProject(network, "fair-manager");

// type anotation is optional
const instance = project.getInstance<FairManagerTypeMap>("production");

const committee = instance.getContract("Committee");
// Old: committee is of BaseContract type
// New: committee is of Committee type imported from fair-managet-types
```

### **3. Automatic type inference after pattern applied to smart-contract projects.**

Only requires to install `@skalenetwork/fair-manager-types/**` as a dependency.
`@skalenetwork/fair-manager-types/**` should have the following piece of code (TODO in each project repository after approved):

```typescript
declare module '@skalenetwork/skale-contracts/lib/projects/fair-manager/fairManagerInstance' {
    interface FairManagerDefaultTypesMap<ContractType> {
        Committee: Committee;
        Status: Status;
        // ... ALL contract names to a type. can be BaseType
    }
}
```

skale-contracts new behaviour (no extra setup required):

```typescript

const project = createProject(network, "fair-manager");

// no type annotation required
const instance = project.getInstance("production");

const committee = instance.getContract("Committee");
// Old: committee is of BaseContract type
// New: committee is of Committee type imported from fair-manager-types
```






