### PR TITLE
Fix credit station imports

### DIFF
--- a/python/src/skale_contracts/projects/__init__.py
+++ b/python/src/skale_contracts/projects/__init__.py
@@ -1,4 +1,5 @@
 """Supported projects"""
+
 from .config_controller import ConfigControllerProject as ConfigController
 from .context import ContextProject as Context
 from .erc1820 import Erc1820Project as Erc1820
@@ -6,13 +7,28 @@ from .etherbase import EtherbaseProject as Etherbase
 from .filestorage import FilestorageProject as FileStorage
 from .marionette import MarionetteProject as Marionette
 from .paymaster import PaymasterProject as Paymaster
-from .ima import \
-    MainnetImaProject as MainnetIma, \
-    SchainImaProject as SchainIma
+from .ima import MainnetImaProject as MainnetIma, SchainImaProject as SchainIma
 from .skale_manager import SkaleManagerProject as SkaleManager
 from .skale_allocator import SkaleAllocatorProject as SkaleAllocator
 from .fair_manager import FairManagerProject as FairManager
+from .credit_station import (
+    MainnetCreditStationProject as MainnetCreditStation,
+    SchainCreditStationProject as SchainCreditStation,
+)
 
-__all__ = ['ConfigController', 'Context', 'Etherbase', 'Erc1820',
-           'FairManager', 'FileStorage', 'MainnetIma', 'Marionette',
-           'Paymaster', 'SchainIma', 'SkaleAllocator', 'SkaleManager']
+__all__ = [
+    "ConfigController",
+    "Context",
+    "Etherbase",
+    "Erc1820",
+    "FairManager",
+    "FileStorage",
+    "MainnetIma",
+    "Marionette",
+    "Paymaster",
+    "SchainIma",
+    "SkaleAllocator",
+    "SkaleManager",
+    "MainnetCreditStation",
+    "SchainCreditStation",
+]


### PR DESCRIPTION
This pull request updates the `python/src/skale_contracts/projects/__init__.py` file to improve project organization and add support for new project types. The most important changes include the addition of Credit Station projects and a cleanup of import formatting.

**New project support:**

* Added imports and exports for `MainnetCreditStationProject` and `SchainCreditStationProject` as `MainnetCreditStation` and `SchainCreditStation`, respectively, expanding the set of supported projects.

**Code organization and formatting:**

* Cleaned up the import statement for `ima` projects by combining them into a single line for readability.
* Reformatted the `__all__` list for clarity and to include the new Credit Station projects.